### PR TITLE
icons; windows; Change search msvc path order from newest to oldest instead

### DIFF
--- a/src/flow/cmd/icons/icons.windows.js
+++ b/src/flow/cmd/icons/icons.windows.js
@@ -33,9 +33,9 @@ exports.convert = function(flow, icon, done) {
     fs.writeFileSync(rcfilepath, rccontent, 'utf8');
 
     	//:todo: configure/safety
-    var vsdir = process.env['VS100COMNTOOLS'] ||
+    var vsdir = process.env['VS120COMNTOOLS'] ||
                 process.env['VS110COMNTOOLS'] ||
-                process.env['VS120COMNTOOLS'];
+                process.env['VS100COMNTOOLS'];
 
     if(!vsdir) {
 


### PR DESCRIPTION
Changed the search order to find the newest VS installation - this can
fix a issue where you could have older and possibly broken installation
from older versions.