### PR TITLE
Use standard library directories for android native libs: armeabi, armeabi-v7a and x86

### DIFF
--- a/src/flow/project/dependencies/hxcpp.flow
+++ b/src/flow/project/dependencies/hxcpp.flow
@@ -40,9 +40,9 @@
         "android && arch-armv7 && !hxcpp_static_std" : {
           build : {
             files : {
-              libregexp : { path:"bin/Android/libregexp-v7.so => project/libs/armeabi/libregexp.so" },
-              libstd : { path:"bin/Android/libstd-v7.so => project/libs/armeabi/libstd.so" },
-              libzlib : { path:"bin/Android/libzlib-v7.so => project/libs/armeabi/libzlib.so" }
+              libregexp : { path:"bin/Android/libregexp-v7.so => project/libs/armeabi-v7a/libregexp.so" },
+              libstd : { path:"bin/Android/libstd-v7.so => project/libs/armeabi-v7a/libstd.so" },
+              libzlib : { path:"bin/Android/libzlib-v7.so => project/libs/armeabi-v7a/libzlib.so" }
             }
           }
         },
@@ -60,9 +60,9 @@
         "android && arch-x86 && !hxcpp_static_std" : {
           build : {
             files : {
-              libregexp : { path:"bin/Android/libregexp-x86.so => project/libs/armeabi/libregexp.so" },
-              libstd : { path:"bin/Android/libstd-x86.so => project/libs/armeabi/libstd.so" },
-              libzlib : { path:"bin/Android/libzlib-x86.so => project/libs/armeabi/libzlib.so" }
+              libregexp : { path:"bin/Android/libregexp-x86.so => project/libs/x86/libregexp.so" },
+              libstd : { path:"bin/Android/libstd-x86.so => project/libs/x86/libstd.so" },
+              libzlib : { path:"bin/Android/libzlib-x86.so => project/libs/x86/libzlib.so" }
             }
           }
         },

--- a/src/flow/project/prepare.js
+++ b/src/flow/project/prepare.js
@@ -109,6 +109,9 @@ internal.prepare_config_paths = function(flow, prepared) {
             case 'x86':
                 flow.project.paths.android.libabi = 'x86';
             break;
+            case 'armv7':
+                flow.project.paths.android.libabi = 'armeabi-v7a';
+            break;
             default:
                 flow.project.paths.android.libabi = 'armeabi';
             break;


### PR DESCRIPTION
Before, armv7 and x86 android binaries were copied to `armeabi` directory instead of `armeabi-v7a` and `x86` directories.

This PR fixes this.